### PR TITLE
Add image-geometry and pcl-ros to gra-base

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -176,6 +176,8 @@ RUN /usr/local/bin/apt-get-wrapper.sh librealsense2-dev librealsense2-dbg librea
 # Configure it to run on port 2222
 # RUN sed -i 's/#Port 22/Port 2222/g' /etc/ssh/sshd_config
 
+# Install libraries for ultralytics
+RUN /usr/local/bin/apt-get-wrapper.sh ros-noetic-image-geometry ros-noetic-pcl-ros
 
 FROM gra-base AS gra-dev
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To enable X11 forwarding, run `xhost +local:docker` on host computer
 
 ## Known issues
 - Ubuntu: memory leak (the memory mysteriously gets full). Deleting the forwarded ports solves the problem some of the time.
-- Windows: git on Windows might change the line endings to CRLF which causes a problem when you build the repo. Make sure your line endings are LF if you get the `/bin/sh: 1: /usr/local/bin/apt-get-wrapper.sh: not found` error. `git config --global core.autocrlf false` and recloning the repo should solve the problem. You will need to modify the git config manually if you are using Github desktop and don't have git installed as s command line tool.
+- Windows: git on Windows might change the line endings to CRLF which causes a problem when you build the repo. Make sure your line endings are LF if you get the `/bin/sh: 1: /usr/local/bin/apt-get-wrapper.sh: not found` error. `git config --global core.autocrlf false` and recloning the repo should solve the problem. You will need to modify the git config manually if you are using Github desktop and don't have git installed as a command line tool.
 
 ## Commonly used commands
 ### Basic ROS

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To enable X11 forwarding, run `xhost +local:docker` on host computer
 
 ## Known issues
 - Ubuntu: memory leak (the memory mysteriously gets full). Deleting the forwarded ports solves the problem some of the time.
-- Windows: git on Windows might change the line endings to CRLF which causes a problem when you build the repo. Make sure your line endings are LF if you get the `/bin/sh: 1: /usr/local/bin/apt-get-wrapper.sh: not found` error. `git config --global core.autocrlf false` and recloning the repo should solve the problem.
+- Windows: git on Windows might change the line endings to CRLF which causes a problem when you build the repo. Make sure your line endings are LF if you get the `/bin/sh: 1: /usr/local/bin/apt-get-wrapper.sh: not found` error. `git config --global core.autocrlf false` and recloning the repo should solve the problem. You will  need to modify the git config manually if you are using Github desktop and don't have git installed as s command line tool.
 
 ## Commonly used commands
 ### Basic ROS

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To enable X11 forwarding, run `xhost +local:docker` on host computer
 
 ## Known issues
 - Ubuntu: memory leak (the memory mysteriously gets full). Deleting the forwarded ports solves the problem some of the time.
-- Windows: git on Windows might change the line endings to CRLF which causes a problem when you build the repo. Make sure your line endings are LF if you get the `/bin/sh: 1: /usr/local/bin/apt-get-wrapper.sh: not found` error. `git config --global core.autocrlf false` and recloning the repo should solve the problem. You will  need to modify the git config manually if you are using Github desktop and don't have git installed as s command line tool.
+- Windows: git on Windows might change the line endings to CRLF which causes a problem when you build the repo. Make sure your line endings are LF if you get the `/bin/sh: 1: /usr/local/bin/apt-get-wrapper.sh: not found` error. `git config --global core.autocrlf false` and recloning the repo should solve the problem. You will need to modify the git config manually if you are using Github desktop and don't have git installed as s command line tool.
 
 ## Commonly used commands
 ### Basic ROS


### PR DESCRIPTION
The Ulralytics package doesn't run without these (they probably come with ros-noetic-desktop but we don't want that on a native installation)