### PR TITLE
Add build.network: host to docker-compose.yml

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: gra-dev
+      network: host
     network_mode: host
     privileged: true
     volumes:


### PR DESCRIPTION
This option configures Docker to run the build stage to run using the host network mode.  The container is already configured to run using the host network mode via the network_mode option.  This fixes issues building the Docker image, particularly with regards to TLS transactions, on all the systems I have access to.